### PR TITLE
add lifeTime getter

### DIFF
--- a/lib/class.cachelite.php
+++ b/lib/class.cachelite.php
@@ -483,6 +483,17 @@ class Cache_Lite
     }
 
     /**
+    * Get the life time
+    *
+    * @return int the life time
+    * @access public
+    */
+    function getLifeTime()
+    {
+        return $this->_lifeTime;
+    }
+
+    /**
     * Save the state of the caching memory array into a cache file cache
     *
     * @param string $id cache id


### PR DESCRIPTION
Provide access to get cache lifeTime. Although $_lifeTime is not really protected or private, it was originally meant to be a protected parameter and should have a getter.
