### PR TITLE
Fix cachelite

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -448,7 +448,6 @@
 			$rules = array_filter(array_map('trim', $rules));
 			if(count($rules) > 0) {
 				foreach($rules as $r) {
-<<<<<<< HEAD
 					// Make sure we're matching `url/blah` not `/url/blah
 					$r = "/" . trim($r, "/"); 
 					//wildcard
@@ -469,32 +468,13 @@
 					}
 					// perfect match
 					else if(strcasecmp($r, $path) == 0) {
-=======
-					$r = str_replace('http://', NULL, $r);
-					$r = str_replace(DOMAIN . '/', NULL, $r);
-					$r = "/" . trim($r, "/"); # Make sure we're matching `/url/blah` not `url/blah
-					if($r == '*') {
-						return true;
-					}
-					elseif(substr($r, -1) == '*') {
-						// page/* is the same as page*
-						$offset = substr($r, -2) == '/' ? 2 : 1;
-						if($r != '*') {
-							 $e = explode("/", $r);
-							 $r = str_replace($e, NULL, $r);
-						}
-						if (strncasecmp($path, $r, strlen($r) - $offset) == 0) {
-							return true;
-						}
-					}
-					elseif(strcasecmp($r, $path) == 0) {
->>>>>>> 3024e03f0429105cebe6b59f173af2fc2faadade
 						return true;
 					}
 				}
 			}
 			return false;
 		}
+
 
 		/*-------------------------------------------------------------------------
 			Database Helpers

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -451,17 +451,24 @@
 					$r = str_replace('http://', NULL, $r);
 					$r = str_replace(DOMAIN . '/', NULL, $r);
 					$r = "/" . trim($r, "/"); # Make sure we're matching `/url/blah` not `url/blah
+				/*	if($r != '*'){
+						$e = explode("/*",$r);
+						$r = str_replace($e, NULL, $r);
+					}*/
 					if($r == '*') {
 						return true;
 					}
 					elseif(substr($r, -1) == '*') {
+						echo "turkish";
 						// page/* is the same as page*
 						$offset = substr($r, -2) == '/' ? 2 : 1;
-						if (strncasecmp($path, $r, strlen($r) - $offset) == 0) {
+						if (strncasecmp($path, $r, strlen($r) - $offset) == 0) {;
+							echo "nanan";
 							return true;
-						}
+						} 
 					}
 					elseif(strcasecmp($r, $path) == 0) {
+						echo "you";
 						return true;
 					}
 				}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -448,6 +448,7 @@
 			$rules = array_filter(array_map('trim', $rules));
 			if(count($rules) > 0) {
 				foreach($rules as $r) {
+<<<<<<< HEAD
 					// Make sure we're matching `url/blah` not `/url/blah
 					$r = "/" . trim($r, "/"); 
 					//wildcard
@@ -468,6 +469,26 @@
 					}
 					// perfect match
 					else if(strcasecmp($r, $path) == 0) {
+=======
+					$r = str_replace('http://', NULL, $r);
+					$r = str_replace(DOMAIN . '/', NULL, $r);
+					$r = "/" . trim($r, "/"); # Make sure we're matching `/url/blah` not `url/blah
+					if($r == '*') {
+						return true;
+					}
+					elseif(substr($r, -1) == '*') {
+						// page/* is the same as page*
+						$offset = substr($r, -2) == '/' ? 2 : 1;
+						if($r != '*') {
+							 $e = explode("/", $r);
+							 $r = str_replace($e, NULL, $r);
+						}
+						if (strncasecmp($path, $r, strlen($r) - $offset) == 0) {
+							return true;
+						}
+					}
+					elseif(strcasecmp($r, $path) == 0) {
+>>>>>>> 3024e03f0429105cebe6b59f173af2fc2faadade
 						return true;
 					}
 				}

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -445,30 +445,29 @@
 			$path = "/" . implode("/", $segments);
 
 			$rules = file(MANIFEST . '/cachelite-excluded-pages', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-			$rules = array_map('trim', $rules);
+			$rules = array_filter(array_map('trim', $rules));
 			if(count($rules) > 0) {
 				foreach($rules as $r) {
-					$r = str_replace('http://', NULL, $r);
-					$r = str_replace(DOMAIN . '/', NULL, $r);
-					$r = "/" . trim($r, "/"); # Make sure we're matching `/url/blah` not `url/blah
-				/*	if($r != '*'){
-						$e = explode("/*",$r);
-						$r = str_replace($e, NULL, $r);
-					}*/
+					// Make sure we're matching `url/blah` not `/url/blah
+					$r = "/" . trim($r, "/"); 
+					//wildcard
 					if($r == '*') {
 						return true;
 					}
-					elseif(substr($r, -1) == '*') {
-						echo "turkish";
-						// page/* is the same as page*
-						$offset = substr($r, -2) == '/' ? 2 : 1;
-						if (strncasecmp($path, $r, strlen($r) - $offset) == 0) {;
-							echo "nanan";
-							return true;
-						} 
+					// wildcard after
+					else if(substr($r, -1) == '*' && strncasecmp($path, $r, strlen($r) - 2) == 0) {
+						return true;
 					}
-					elseif(strcasecmp($r, $path) == 0) {
-						echo "you";
+					// wildcard before
+					else if(substr($r, -1) == '*' && strpos($r, $path) !== false) {
+						return true;
+					}
+					// wildcard before and after
+					else if(substr($r, -1) == '*' && substr($r, 0) == '*' && strncasecmp($path, $r, strlen($r) - 2) == 0) {
+						return true;
+					}
+					// perfect match
+					else if(strcasecmp($r, $path) == 0) {
 						return true;
 					}
 				}

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,6 +15,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.3.3" date="2016-08-07" min="2.3.x" max="2.x.x">
+			- Fixed an issue with Excluding pages
+		</release>
 		<release version="1.3.2" date="2016-05-17" min="2.3.x" max="2.x.x">
 			- Fixed an issue when the page xml is not valid
 		</release>

--- a/lib/class.cachelite.php
+++ b/lib/class.cachelite.php
@@ -291,7 +291,7 @@ class Cache_Lite
             $this->setOption($key, $value);
         }
         if (!isset($options['cacheDir']) && function_exists('sys_get_temp_dir')) {
-        	$this->setOption('cacheDir', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
+            $this->setOption('cacheDir', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
         }
     }
     
@@ -386,14 +386,15 @@ class Cache_Lite
                     return true;
                 }
             }
-            if ($this->_automaticCleaningFactor>0 && ($this->_automaticCleaningFactor==1 || mt_rand(1, $this->_automaticCleaningFactor)==1)) {
-				$this->clean(false, 'old');			
-			}
+            if ($this->_automaticCleaningFactor > 0 && ($this->_automaticCleaningFactor == 1 || mt_rand(1, $this->_automaticCleaningFactor) == 1)) {
+                die;
+                $this->clean(false, 'old');
+            }
             if ($this->_writeControl) {
                 $res = $this->_writeAndControl($data);
                 if (is_bool($res)) {
                     if ($res) {
-                        return true;  
+                        return true;
                     }
                     // if $res if false, we need to invalidate the cache
                     @touch($this->_file, time() - 2*abs($this->_lifeTime));
@@ -613,7 +614,7 @@ class Cache_Lite
     * @return boolean true if no problem
     * @access private
     */
-    function _cleanDir($dir, $group = false, $mode = 'ingroup')     
+    function _cleanDir($dir, $group = false, $mode = 'ingroup')
     {
         if ($this->_fileNameProtection) {
             $motif = ($group) ? 'cache_'.md5($group).'_' : 'cache_';
@@ -621,7 +622,7 @@ class Cache_Lite
             $motif = ($group) ? 'cache_'.$group.'_' : 'cache_';
         }
         if ($this->_memoryCaching) {
-	    foreach($this->_memoryCachingArray as $key => $v) {
+        foreach($this->_memoryCachingArray as $key => $v) {
                 if (strpos($key, $motif) !== false) {
                     unset($this->_memoryCachingArray[$key]);
                     $this->_memoryCachingCounter = $this->_memoryCachingCounter - 1;
@@ -714,7 +715,7 @@ class Cache_Lite
             $hash = md5($suffix);
             for ($i=0 ; $i<$this->_hashedDirectoryLevel ; $i++) {
                 $root = $root . 'cache_' . substr($hash, 0, $i + 1) . '/';
-            }   
+            }
         }
         $this->_fileName = $suffix;
         $this->_file = $root.$suffix;
@@ -730,7 +731,7 @@ class Cache_Lite
     {
         $fp = @fopen($this->_file, "rb");
         if ($fp) {
-	    if ($this->_fileLocking) @flock($fp, LOCK_SH);
+        if ($this->_fileLocking) @flock($fp, LOCK_SH);
             clearstatcache();
             $length = @filesize($this->_file);
             $mqr = get_magic_quotes_runtime();
@@ -803,7 +804,7 @@ class Cache_Lite
             if ($this->_fileLocking) @flock($fp, LOCK_UN);
             @fclose($fp);
             return true;
-        }      
+        }
         return $this->raiseError('Cache_Lite : Unable to write cache file : '.$this->_file, -1);
     }
        

--- a/lib/class.cachelite.php
+++ b/lib/class.cachelite.php
@@ -387,7 +387,6 @@ class Cache_Lite
                 }
             }
             if ($this->_automaticCleaningFactor > 0 && ($this->_automaticCleaningFactor == 1 || mt_rand(1, $this->_automaticCleaningFactor) == 1)) {
-                die;
                 $this->clean(false, 'old');
             }
             if ($this->_writeControl) {
@@ -622,7 +621,7 @@ class Cache_Lite
             $motif = ($group) ? 'cache_'.$group.'_' : 'cache_';
         }
         if ($this->_memoryCaching) {
-        foreach($this->_memoryCachingArray as $key => $v) {
+            foreach($this->_memoryCachingArray as $key => $v) {
                 if (strpos($key, $motif) !== false) {
                     unset($this->_memoryCachingArray[$key]);
                     $this->_memoryCachingCounter = $this->_memoryCachingCounter - 1;
@@ -731,39 +730,39 @@ class Cache_Lite
     {
         $fp = @fopen($this->_file, "rb");
         if ($fp) {
-        if ($this->_fileLocking) @flock($fp, LOCK_SH);
-            clearstatcache();
-            $length = @filesize($this->_file);
-            $mqr = get_magic_quotes_runtime();
-            if ($mqr) {
-                set_magic_quotes_runtime(0);
-            }
-            if ($this->_readControl) {
-                $hashControl = @fread($fp, 32);
-                $length = $length - 32;
-            } 
-            if ($length) {
-                $data = @fread($fp, $length);
-            } else {
-                $data = '';
-            }
-            if ($mqr) {
-                set_magic_quotes_runtime($mqr);
-            }
-            if ($this->_fileLocking) @flock($fp, LOCK_UN);
-            @fclose($fp);
-            if ($this->_readControl) {
-                $hashData = $this->_hash($data, $this->_readControlType);
-                if ($hashData != $hashControl) {
-                    if (!(is_null($this->_lifeTime))) {
-                        @touch($this->_file, time() - 2*abs($this->_lifeTime)); 
-                    } else {
-                        @unlink($this->_file);
-                    }
-                    return false;
+            if ($this->_fileLocking) @flock($fp, LOCK_SH);
+                clearstatcache();
+                $length = @filesize($this->_file);
+                $mqr = get_magic_quotes_runtime();
+                if ($mqr) {
+                    set_magic_quotes_runtime(0);
                 }
-            }
-            return $data;
+                if ($this->_readControl) {
+                    $hashControl = @fread($fp, 32);
+                    $length = $length - 32;
+                } 
+                if ($length) {
+                    $data = @fread($fp, $length);
+                } else {
+                    $data = '';
+                }
+                if ($mqr) {
+                    set_magic_quotes_runtime($mqr);
+                }
+                if ($this->_fileLocking) @flock($fp, LOCK_UN);
+                @fclose($fp);
+                if ($this->_readControl) {
+                    $hashData = $this->_hash($data, $this->_readControlType);
+                    if ($hashData != $hashControl) {
+                        if (!(is_null($this->_lifeTime))) {
+                            @touch($this->_file, time() - 2*abs($this->_lifeTime)); 
+                        } else {
+                            @unlink($this->_file);
+                        }
+                        return false;
+                    }
+                }
+                return $data;
         }
         return $this->raiseError('Cache_Lite : Unable to read cache !', -2); 
     }


### PR DESCRIPTION
Multiple issue fixed on the method _in_excluded_pages().
It will now behave normally and respect : 
Excluding pages 
- Preferences. Each URL must sit on a separate line and wildcards (*) may be used at the end of URLs to match everything below that URL.
/about-us/get-in-touch/*
http://root.com/about-us/get-in-touch/
about-us/get-in-touch*
/about-us/get*